### PR TITLE
add type/generation compatibility mapping

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,28 +1,35 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ["dist"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
-    files: ['**/*.{ts,tsx}'],
+    files: ["**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
     },
     plugins: {
-      'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
+      "react-refresh/only-export-components": [
+        "warn",
         { allowConstantExport: true },
+      ],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
       ],
     },
   },
-)
+);

--- a/src/components/Filters/FilterSelect.tsx
+++ b/src/components/Filters/FilterSelect.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/select";
 import { useGuessContext } from "@/context/useGuessContext";
 import { RegionString, TypeString } from "@/lib/api/types";
+import { getAvailableTypesForRegion, getAvailableRegionsForType } from "@/lib/api/type-compatibility";
 
 type FilterProps = {
   optionsArr: string[];
@@ -14,7 +15,7 @@ type FilterProps = {
 };
 
 export default function FilterSelect({ optionsArr, menuTitle }: FilterProps) {
-  const { setRegion, setType, guessesRemaining } = useGuessContext();
+  const { setRegion, setType, guessesRemaining, region, type } = useGuessContext();
   const isGuessInProgress = guessesRemaining < 7;
 
   function handleSelect(value: string) {
@@ -25,6 +26,29 @@ export default function FilterSelect({ optionsArr, menuTitle }: FilterProps) {
     }
   }
 
+  function isOptionDisabled(option: string): boolean {
+    const optionLower = option.toLowerCase();
+    
+    // "All" option is never disabled
+    if (optionLower === "all") return false;
+    
+    if (menuTitle === "Region") {
+      // Disable regions that don't have the selected type
+      if (type !== "all") {
+        const availableRegions = getAvailableRegionsForType(type as TypeString);
+        return !availableRegions.includes(optionLower as RegionString);
+      }
+    } else if (menuTitle === "Type") {
+      // Disable types that aren't available in the selected region
+      if (region !== "all") {
+        const availableTypes = getAvailableTypesForRegion(region as RegionString);
+        return !availableTypes.includes(optionLower as TypeString);
+      }
+    }
+    
+    return false;
+  }
+
   return (
     <div className="rounded-lg border-2 border-blue-900 bg-yellow-100 p-1 font-semibold text-blue-900">
       <Select onValueChange={handleSelect} disabled={isGuessInProgress}>
@@ -33,8 +57,14 @@ export default function FilterSelect({ optionsArr, menuTitle }: FilterProps) {
         </SelectTrigger>
         <SelectContent className="font-utility bg-yellow-100 text-blue-900">
           {optionsArr.map((option) => {
+            const disabled = isOptionDisabled(option);
             return (
-              <SelectItem key={option} value={option}>
+              <SelectItem 
+                key={option} 
+                value={option} 
+                disabled={disabled}
+                className={disabled ? "text-gray-400 cursor-not-allowed" : ""}
+              >
                 {option}
               </SelectItem>
             );

--- a/src/lib/api/type-compatibility.ts
+++ b/src/lib/api/type-compatibility.ts
@@ -1,0 +1,91 @@
+import { RegionString, TypeString } from "./types";
+
+// Type introduction by generation
+export const TYPE_GENERATION_MAP = {
+  normal: 1,
+  fighting: 1,
+  flying: 1,
+  poison: 1,
+  ground: 1,
+  rock: 1,
+  bug: 1,
+  ghost: 1,
+  fire: 1,
+  water: 1,
+  grass: 1,
+  electric: 1,
+  psychic: 1,
+  ice: 1,
+  dragon: 1,
+  dark: 2, // Introduced in Generation 2 (Johto)
+  steel: 2, // Introduced in Generation 2 (Johto)
+  fairy: 6, // Introduced in Generation 6 (Kalos)
+} as const;
+
+// Region to generation mapping
+export const REGION_GENERATION_MAP = {
+  kanto: 1,
+  johto: 2,
+  hoenn: 3,
+  sinnoh: 4,
+  unova: 5,
+  kalos: 6,
+  alola: 7,
+  galar: 8,
+  paldea: 9,
+} as const;
+
+/**
+ * Check if a type is available in a specific region
+ */
+export function isTypeAvailableInRegion(
+  type: TypeString,
+  region: RegionString,
+): boolean {
+  if (type === "all" || region === "all") return true;
+
+  const typeGeneration =
+    TYPE_GENERATION_MAP[type as keyof typeof TYPE_GENERATION_MAP];
+  const regionGeneration =
+    REGION_GENERATION_MAP[region as keyof typeof REGION_GENERATION_MAP];
+
+  if (!typeGeneration || !regionGeneration) return true; // fallback for unknown types/regions
+
+  return typeGeneration <= regionGeneration;
+}
+
+/**
+ * Get all types available in a specific region
+ */
+export function getAvailableTypesForRegion(region: RegionString): TypeString[] {
+  if (region === "all") {
+    return Object.keys(TYPE_GENERATION_MAP) as TypeString[];
+  }
+
+  const regionGeneration =
+    REGION_GENERATION_MAP[region as keyof typeof REGION_GENERATION_MAP];
+  if (!regionGeneration)
+    return Object.keys(TYPE_GENERATION_MAP) as TypeString[];
+
+  return Object.entries(TYPE_GENERATION_MAP)
+    .filter(([_, typeGeneration]) => typeGeneration <= regionGeneration)
+    .map(([type, _]) => type as TypeString);
+}
+
+/**
+ * Get all regions where a specific type is available
+ */
+export function getAvailableRegionsForType(type: TypeString): RegionString[] {
+  if (type === "all") {
+    return Object.keys(REGION_GENERATION_MAP) as RegionString[];
+  }
+
+  const typeGeneration =
+    TYPE_GENERATION_MAP[type as keyof typeof TYPE_GENERATION_MAP];
+  if (!typeGeneration)
+    return Object.keys(REGION_GENERATION_MAP) as RegionString[];
+
+  return Object.entries(REGION_GENERATION_MAP)
+    .filter(([_, regionGeneration]) => regionGeneration >= typeGeneration)
+    .map(([region, _]) => region as RegionString);
+}


### PR DESCRIPTION
  1. Type-Generation Compatibility Mapping (/src/lib/api/type-compatibility.ts):

- Maps each type to its introduction generation (e.g., Dark/Steel in Gen 2, Fairy in Gen 6)
- Maps each region to its generation number
- Provides utility functions to check compatibility

 2. Dynamic Filter Disabling (FilterSelect.tsx):

- Region filter: Disables regions that don't have the selected type
- Type filter: Disables types that weren't available in the selected region
- Visual feedback: Disabled options are grayed out and non-clickable

  How It Works:

  - Select Kanto region → Dark, Steel, and Fairy types become disabled
  - Select Fairy type → Only Kalos, Alola, Galar, and Paldea regions remain enabled
  - Select "All" → All options become available again

  User Experience:

  - Prevents frustration: Users can't select invalid combinations
  - Educational: Shows which types were available in each generation
  - Intuitive: Clear visual feedback with disabled/grayed options
  - Responsive: Updates immediately when selections change